### PR TITLE
fix(windows): prevent popover shrink during header press/drag on high…

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -50,6 +50,7 @@ let popover;
 let popoverSizeSaveTimer = null;
 let isMovingPopover = false;
 let popoverSizeAtMoveStart = null;
+let moveEndFallbackTimer = null;
 let desktopPet;
 let desktopPetTimer = null;
 let desktopPetPositionSaveTimer = null;
@@ -166,7 +167,7 @@ function scheduleSavePopoverSize() {
   // Windows may fire a spurious WM_SIZE during setPosition on frameless
   // windows — skip the save while a move is in flight so a transient
   // wrong size is never persisted to settings.
-  if (isMovingPopover) return;
+  if (process.platform === 'win32' && isMovingPopover) return;
   clearTimeout(popoverSizeSaveTimer);
   popoverSizeSaveTimer = setTimeout(() => {
     if (!popover || popover.isDestroyed()) return;
@@ -205,6 +206,20 @@ function resizePopoverDrag({ edge = "se", start = {}, dx = 0, dy = 0 } = {}) {
   return { x, y, width, height };
 }
 
+// Shared fallback: if the renderer crashes or the pointer is released outside
+// the window (no pointerup on document), reset after 5 s of inactivity so the
+// size-save guard does not stay locked forever.  Reset on every move so an
+// active long-press never trips the timeout.
+function resetMoveEndFallback() {
+  clearTimeout(moveEndFallbackTimer);
+  moveEndFallbackTimer = setTimeout(() => {
+    isMovingPopover = false;
+    // popoverSizeAtMoveStart intentionally NOT cleared —
+    // it's the only defense against cumulative WM_SIZE shrinks.
+    // Next getPopoverBounds (new drag) overwrites it with fresh values.
+  }, 5000);
+}
+
 // Move the popover to an absolute screen position, clamped so it stays within
 // the work area of whichever display the target point lands on. Used by the
 // "carry her around the screen" gesture in the renderer.
@@ -221,12 +236,15 @@ function movePopoverTo(point = {}) {
   const work = display.workArea;
   const x = clampNumber(targetX, work.x, work.x + work.width - bounds.width);
   const y = clampNumber(targetY, work.y, work.y + work.height - bounds.height);
-  isMovingPopover = true;
-  // Lock the size to what it was when the drag started so Windows cannot
-  // accumulate spurious WM_SIZE shrinks across successive setBounds calls.
-  const w = popoverSizeAtMoveStart?.width ?? bounds.width;
-  const h = popoverSizeAtMoveStart?.height ?? bounds.height;
-  popover.setBounds({ x, y, width: w, height: h }, false);
+  if (process.platform === 'win32') {
+    isMovingPopover = true;
+    resetMoveEndFallback();
+    const w = popoverSizeAtMoveStart?.width ?? bounds.width;
+    const h = popoverSizeAtMoveStart?.height ?? bounds.height;
+    popover.setBounds({ x, y, width: w, height: h }, false);
+  } else {
+    popover.setPosition(x, y, false);
+  }
   return { x, y };
 }
 
@@ -1365,15 +1383,21 @@ ipcMain.handle("popover:move", (_, point) => movePopoverTo(point));
 
 ipcMain.handle("popover:get-bounds", () => {
   if (!popover || popover.isDestroyed()) return null;
-  isMovingPopover = true;
-  const bounds = popover.getBounds();
-  popoverSizeAtMoveStart = { width: bounds.width, height: bounds.height };
-  return bounds;
+  if (process.platform === 'win32') {
+    isMovingPopover = true;
+    const bounds = popover.getBounds();
+    popoverSizeAtMoveStart = { width: bounds.width, height: bounds.height };
+    resetMoveEndFallback();
+    return bounds;
+  }
+  return popover.getBounds();
 });
 
 ipcMain.handle("popover:move-end", () => {
+  if (process.platform !== 'win32') return;
   isMovingPopover = false;
   popoverSizeAtMoveStart = null;
+  clearTimeout(moveEndFallbackTimer);
 });
 
 ipcMain.handle("popover:resize-drag", (_, payload) => resizePopoverDrag(payload));

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -48,6 +48,8 @@ const DESKTOP_PET_SIZES = Object.freeze({
 let tray;
 let popover;
 let popoverSizeSaveTimer = null;
+let isMovingPopover = false;
+let popoverSizeAtMoveStart = null;
 let desktopPet;
 let desktopPetTimer = null;
 let desktopPetPositionSaveTimer = null;
@@ -161,6 +163,10 @@ function initialPopoverSize() {
 
 function scheduleSavePopoverSize() {
   if (!popover || popover.isDestroyed()) return;
+  // Windows may fire a spurious WM_SIZE during setPosition on frameless
+  // windows — skip the save while a move is in flight so a transient
+  // wrong size is never persisted to settings.
+  if (isMovingPopover) return;
   clearTimeout(popoverSizeSaveTimer);
   popoverSizeSaveTimer = setTimeout(() => {
     if (!popover || popover.isDestroyed()) return;
@@ -215,7 +221,12 @@ function movePopoverTo(point = {}) {
   const work = display.workArea;
   const x = clampNumber(targetX, work.x, work.x + work.width - bounds.width);
   const y = clampNumber(targetY, work.y, work.y + work.height - bounds.height);
-  popover.setPosition(x, y, false);
+  isMovingPopover = true;
+  // Lock the size to what it was when the drag started so Windows cannot
+  // accumulate spurious WM_SIZE shrinks across successive setBounds calls.
+  const w = popoverSizeAtMoveStart?.width ?? bounds.width;
+  const h = popoverSizeAtMoveStart?.height ?? bounds.height;
+  popover.setBounds({ x, y, width: w, height: h }, false);
   return { x, y };
 }
 
@@ -1354,7 +1365,15 @@ ipcMain.handle("popover:move", (_, point) => movePopoverTo(point));
 
 ipcMain.handle("popover:get-bounds", () => {
   if (!popover || popover.isDestroyed()) return null;
-  return popover.getBounds();
+  isMovingPopover = true;
+  const bounds = popover.getBounds();
+  popoverSizeAtMoveStart = { width: bounds.width, height: bounds.height };
+  return bounds;
+});
+
+ipcMain.handle("popover:move-end", () => {
+  isMovingPopover = false;
+  popoverSizeAtMoveStart = null;
 });
 
 ipcMain.handle("popover:resize-drag", (_, payload) => resizePopoverDrag(payload));

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -9,6 +9,7 @@ function onChannel(channel) {
 }
 
 contextBridge.exposeInMainWorld("petApi", {
+  isWindows: process.platform === 'win32',
   hidePopover: () => ipcRenderer.invoke("popover:hide"),
   getPopoverBounds: () => ipcRenderer.invoke("popover:get-bounds"),
   resizePopoverDrag: (payload) => ipcRenderer.invoke("popover:resize-drag", payload),

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -13,6 +13,7 @@ contextBridge.exposeInMainWorld("petApi", {
   getPopoverBounds: () => ipcRenderer.invoke("popover:get-bounds"),
   resizePopoverDrag: (payload) => ipcRenderer.invoke("popover:resize-drag", payload),
   movePopover: (point) => ipcRenderer.invoke("popover:move", point),
+  endMovePopover: () => ipcRenderer.invoke("popover:move-end"),
   notePopoverActivity: () => ipcRenderer.invoke("popover:activity"),
   openChatFromDesktopPet: () => ipcRenderer.invoke("desktop-pet:open-chat"),
   moveDesktopPet: (point) => ipcRenderer.invoke("desktop-pet:move", point),

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -736,52 +736,76 @@ const dragHandle = document.getElementById("dragHandle");
 let isWindowMoving = false;
 let winMoveStartScreenX = 0;
 let winMoveStartScreenY = 0;
-let winMoveStartX = 0;
-let winMoveStartY = 0;
+// NaN sentinel — move IPC skips pointer-move events until the main process
+// responds with real bounds, so mixed CSS/device-pixel coordinates on Windows
+// DPI scaling cannot drift the window position toward the wrong corner.
+let winMoveStartX = NaN;
+let winMoveStartY = NaN;
 
-function handleHeaderPointerDown(event) {
+const MOVE_THRESHOLD = 3; // px — ignore sub-pixel jitter on quiet input devices
+
+async function handleHeaderPointerDown(event) {
   if (event.button !== 0) return;
-  // Let the Clear/Stop buttons (and any control) work normally.
   if (event.target.closest("button")) return;
+  event.preventDefault();
+  event.stopPropagation();
   isWindowMoving = true;
   winMoveStartScreenX = event.screenX;
   winMoveStartScreenY = event.screenY;
-  winMoveStartX = window.screenX;
-  winMoveStartY = window.screenY;
-  try {
-    dragHandle.setPointerCapture(event.pointerId);
-  } catch {
-    /* continue without capture */
-  }
   document.body.classList.add("is-window-moving");
   lockMood("happy", { durationMs: DRAG_LOCK_DURATION });
+
+  // Use document-level listeners instead of setPointerCapture to avoid
+  // Win32 SetCapture() triggering spurious WM_SIZE on Windows frameless
+  // windows — that shrinks the popover continuously while pressed.
+  document.addEventListener("pointermove", handleHeaderPointerMove);
+  document.addEventListener("pointerup", handleHeaderPointerUpOnce);
+  document.addEventListener("pointercancel", handleHeaderPointerUpOnce);
+
+  const bounds = await window.petApi?.getPopoverBounds?.();
+  if (!isWindowMoving || !bounds) return;
+  winMoveStartX = bounds.x;
+  winMoveStartY = bounds.y;
 }
 
 function handleHeaderPointerMove(event) {
   if (!isWindowMoving) return;
+  if (!Number.isFinite(winMoveStartX)) return;
+
+  const dx = event.screenX - winMoveStartScreenX;
+  const dy = event.screenY - winMoveStartScreenY;
+  if (Math.abs(dx) < MOVE_THRESHOLD && Math.abs(dy) < MOVE_THRESHOLD) return;
+
   event.preventDefault();
+  const dpr = window.devicePixelRatio || 1;
   window.petApi?.movePopover?.({
-    x: winMoveStartX + (event.screenX - winMoveStartScreenX),
-    y: winMoveStartY + (event.screenY - winMoveStartScreenY)
+    x: winMoveStartX + dx * dpr,
+    y: winMoveStartY + dy * dpr
   })?.catch?.(() => {});
+}
+
+function handleHeaderPointerUpOnce(event) {
+  document.removeEventListener("pointermove", handleHeaderPointerMove);
+  document.removeEventListener("pointerup", handleHeaderPointerUpOnce);
+  document.removeEventListener("pointercancel", handleHeaderPointerUpOnce);
+  handleHeaderPointerUp(event);
 }
 
 function handleHeaderPointerUp(event) {
   if (!isWindowMoving) return;
   isWindowMoving = false;
-  try {
-    dragHandle.releasePointerCapture(event.pointerId);
-  } catch {
-    /* already released */
-  }
+  winMoveStartX = NaN;
+  winMoveStartY = NaN;
   document.body.classList.remove("is-window-moving");
   releaseClickLock();
+  window.petApi?.endMovePopover?.()?.catch?.(() => {});
 }
 
 dragHandle?.addEventListener("pointerdown", handleHeaderPointerDown);
-dragHandle?.addEventListener("pointermove", handleHeaderPointerMove);
-dragHandle?.addEventListener("pointerup", handleHeaderPointerUp);
-dragHandle?.addEventListener("pointercancel", handleHeaderPointerUp);
+// pointermove / pointerup are registered on document during drag so the
+// pointer is tracked even when it leaves the header — without invoking
+// setPointerCapture, whose underlying Win32 SetCapture() causes the
+// spurious WM_SIZE on Windows frameless windows.
 
 function handleStageClick(event) {
   if (justDragged) {

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -743,24 +743,38 @@ let winMoveStartX = NaN;
 let winMoveStartY = NaN;
 
 const MOVE_THRESHOLD = 3; // px — ignore sub-pixel jitter on quiet input devices
+const IS_WINDOWS = window.petApi?.isWindows === true;
 
 async function handleHeaderPointerDown(event) {
   if (event.button !== 0) return;
   if (event.target.closest("button")) return;
-  event.preventDefault();
-  event.stopPropagation();
   isWindowMoving = true;
   winMoveStartScreenX = event.screenX;
   winMoveStartScreenY = event.screenY;
+
+  if (IS_WINDOWS) {
+    event.preventDefault();
+    event.stopPropagation();
+    // Tear down any stale listeners from a previous drag whose pointerup
+    // was lost (e.g. released outside the window at a screen edge).
+    document.removeEventListener("pointermove", handleHeaderPointerMove);
+    document.removeEventListener("pointerup", handleHeaderPointerUpOnce);
+    document.removeEventListener("pointercancel", handleHeaderPointerUpOnce);
+    // Document-level listeners avoid Win32 SetCapture() → spurious WM_SIZE
+    // on frameless windows that shrinks the popover while pressed.
+    document.addEventListener("pointermove", handleHeaderPointerMove);
+    document.addEventListener("pointerup", handleHeaderPointerUpOnce);
+    document.addEventListener("pointercancel", handleHeaderPointerUpOnce);
+  } else {
+    try {
+      dragHandle.setPointerCapture(event.pointerId);
+    } catch {
+      /* continue without capture */
+    }
+  }
+
   document.body.classList.add("is-window-moving");
   lockMood("happy", { durationMs: DRAG_LOCK_DURATION });
-
-  // Use document-level listeners instead of setPointerCapture to avoid
-  // Win32 SetCapture() triggering spurious WM_SIZE on Windows frameless
-  // windows — that shrinks the popover continuously while pressed.
-  document.addEventListener("pointermove", handleHeaderPointerMove);
-  document.addEventListener("pointerup", handleHeaderPointerUpOnce);
-  document.addEventListener("pointercancel", handleHeaderPointerUpOnce);
 
   const bounds = await window.petApi?.getPopoverBounds?.();
   if (!isWindowMoving || !bounds) return;
@@ -777,13 +791,13 @@ function handleHeaderPointerMove(event) {
   if (Math.abs(dx) < MOVE_THRESHOLD && Math.abs(dy) < MOVE_THRESHOLD) return;
 
   event.preventDefault();
-  const dpr = window.devicePixelRatio || 1;
   window.petApi?.movePopover?.({
-    x: winMoveStartX + dx * dpr,
-    y: winMoveStartY + dy * dpr
+    x: winMoveStartX + dx,
+    y: winMoveStartY + dy
   })?.catch?.(() => {});
 }
 
+// Windows only: wrapper that tears down document-level listeners
 function handleHeaderPointerUpOnce(event) {
   document.removeEventListener("pointermove", handleHeaderPointerMove);
   document.removeEventListener("pointerup", handleHeaderPointerUpOnce);
@@ -796,16 +810,36 @@ function handleHeaderPointerUp(event) {
   isWindowMoving = false;
   winMoveStartX = NaN;
   winMoveStartY = NaN;
+
+  if (IS_WINDOWS) {
+    // document listeners are torn down by handleHeaderPointerUpOnce above
+  } else {
+    try {
+      dragHandle.releasePointerCapture(event.pointerId);
+    } catch {
+      /* already released */
+    }
+  }
+
   document.body.classList.remove("is-window-moving");
   releaseClickLock();
-  window.petApi?.endMovePopover?.()?.catch?.(() => {});
+
+  if (IS_WINDOWS) {
+    window.petApi?.endMovePopover?.()?.catch?.(() => {});
+  }
 }
 
 dragHandle?.addEventListener("pointerdown", handleHeaderPointerDown);
-// pointermove / pointerup are registered on document during drag so the
-// pointer is tracked even when it leaves the header — without invoking
-// setPointerCapture, whose underlying Win32 SetCapture() causes the
-// spurious WM_SIZE on Windows frameless windows.
+if (IS_WINDOWS) {
+  // pointermove / pointerup are registered on document during drag so the
+  // pointer is tracked even when it leaves the header — without invoking
+  // setPointerCapture, whose underlying Win32 SetCapture() causes the
+  // spurious WM_SIZE on Windows frameless windows.
+} else {
+  dragHandle?.addEventListener("pointermove", handleHeaderPointerMove);
+  dragHandle?.addEventListener("pointerup", handleHeaderPointerUp);
+  dragHandle?.addEventListener("pointercancel", handleHeaderPointerUp);
+}
 
 function handleStageClick(event) {
   if (justDragged) {


### PR DESCRIPTION
修复：Windows 高 DPI 下拖动标题栏导致窗口异常缩小
原因： 
1. setPointerCapture → Win32 SetCapture() 触发虚假 WM_SIZE
  渲染进程在 pointerdown 时调用 dragHandle.setPointerCapture()，这行代码在 Chromium/Electron 内部调用 Win32 SetCapture()
  API。对于 frame: false的 Electron 窗口会导致以下结果：
  - SetCapture() 改变窗口的鼠标消息路由
  - Windows DWM 对无边框窗口在 SetCapture() 激活期间会重新评估窗口尺寸约束
  - 触发一系列 WM_GETMINMAXINFO / WM_SIZE 消息，导致窗口持续缩小
  - 松开时 ReleaseCapture() 被调用，缩小停止

  2. setPosition 触发 WM_SIZE
  每次 pointermove 调用 popover.setPosition() 移动窗口，Windows 在 frameless 窗口上会额外发送 WM_SIZE
  消息。每次拖拽帧都触发一次缩小，累积到最小尺寸。

  3. 坐标系不匹配
  - BrowserWindow.getBounds() 返回物理像素（150% DPI 下 1 CSS px = 1.5 物理 px）
  - PointerEvent.screenX 返回CSS 像素
  - 差值 dx 是 CSS 像素，直接加到物理像素的 bounds.x 上，导致窗口移动距离只有指针的 1/dpr
  - 150% DPI 下窗口只移动指针实际距离的 67%