### PR TITLE
feat: 增加了一个可以自动展示html网页的侧页

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "electron-updater": "^6.8.3"
       },
       "devDependencies": {
-        "electron": "^42.3.0",
+        "electron": "^42.3.3",
         "electron-builder": "^26.8.1"
       }
     },
@@ -1505,9 +1505,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.3.0.tgz",
-      "integrity": "sha512-9ZiLdRXk+WDxW1OgIUz8J2rIQ5TYU9o629gCOjU48Q3dQiOmym7osWsH5Ubs/Jh4uuFLn6m6SBD2rmRXLAPz9g==",
+      "version": "42.3.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.3.3.tgz",
+      "integrity": "sha512-0MwYp9wTb7TrtTalOYqeW+suqd9T/Znstr/nDLKqFGIjHdBZX339guo3mQqTPURRZ/UQmYM4uMpzKpI5wLptfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "",
   "license": "UNLICENSED",
   "devDependencies": {
-    "electron": "^42.3.0",
+    "electron": "^42.3.3",
     "electron-builder": "^26.8.1"
   },
   "build": {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -39,6 +39,7 @@ const POPOVER_MIN_HEIGHT = 460;
 // the popover can grow right up to the screen edges on large monitors.
 const POPOVER_EDGE_MARGIN = 8;
 const DESKTOP_PET_IDLE_MS = Number(process.env.PRTS_DESKTOP_PET_IDLE_MS) || 60 * 1000;
+const HTML_PANEL_MIN_WIDTH = 200;
 const DESKTOP_PET_SIZES = Object.freeze({
   small: { width: 120, height: 144 },
   medium: { width: 150, height: 180 },
@@ -61,6 +62,8 @@ let desktopPet;
 let desktopPetTimer = null;
 let desktopPetPositionSaveTimer = null;
 let windowFadeTimer = null;
+let htmlPanelOpen = false;
+let htmlPanelWidth = 0;
 
 // ============================================================
 //  Tray icon — prefer the dedicated centered icon.png, fallback
@@ -155,10 +158,13 @@ function clampNumber(value, min, max) {
 
 function clampPopoverSize(size = {}, display = screen.getPrimaryDisplay()) {
   const work = display.workArea;
-  const maxWidth = Math.max(POPOVER_MIN_WIDTH, work.width - POPOVER_EDGE_MARGIN);
+  const effectiveMinWidth = htmlPanelOpen
+    ? POPOVER_MIN_WIDTH + HTML_PANEL_MIN_WIDTH
+    : POPOVER_MIN_WIDTH;
+  const maxWidth = Math.max(effectiveMinWidth, work.width - POPOVER_EDGE_MARGIN);
   const maxHeight = Math.max(POPOVER_MIN_HEIGHT, work.height - POPOVER_EDGE_MARGIN);
   return {
-    width: clampNumber(size.width ?? POPOVER_DEFAULT_WIDTH, POPOVER_MIN_WIDTH, maxWidth),
+    width: clampNumber(size.width ?? POPOVER_DEFAULT_WIDTH, effectiveMinWidth, maxWidth),
     height: clampNumber(size.height ?? POPOVER_DEFAULT_HEIGHT, POPOVER_MIN_HEIGHT, maxHeight)
   };
 }
@@ -177,7 +183,13 @@ function scheduleSavePopoverSize() {
   clearTimeout(popoverSizeSaveTimer);
   popoverSizeSaveTimer = setTimeout(() => {
     if (!popover || popover.isDestroyed()) return;
-    const size = clampPopoverSize(popover.getBounds(), screen.getDisplayMatching(popover.getBounds()));
+    const bounds = popover.getBounds();
+    const size = clampPopoverSize(bounds, screen.getDisplayMatching(bounds));
+    // Save the base width without the HTML panel, so restarting the app
+    // doesn't open a wide window while the panel is hidden.
+    if (htmlPanelOpen && htmlPanelWidth > 0) {
+      size.width = Math.max(POPOVER_MIN_WIDTH, size.width - htmlPanelWidth);
+    }
     settings.set({ popoverSize: size });
   }, 350);
 }
@@ -195,12 +207,15 @@ function resizePopoverDrag({ edge = "se", start = {}, dx = 0, dy = 0 } = {}) {
   const e = String(edge);
   const right = sx + sw;
   const bottom = sy + sh;
-  const maxWidth = Math.max(POPOVER_MIN_WIDTH, work.width - POPOVER_EDGE_MARGIN);
+  const effectiveMinWidth = htmlPanelOpen
+    ? POPOVER_MIN_WIDTH + HTML_PANEL_MIN_WIDTH
+    : POPOVER_MIN_WIDTH;
+  const maxWidth = Math.max(effectiveMinWidth, work.width - POPOVER_EDGE_MARGIN);
   const maxHeight = Math.max(POPOVER_MIN_HEIGHT, work.height - POPOVER_EDGE_MARGIN);
 
   let width = sw + (e.includes("e") ? dx : 0) - (e.includes("w") ? dx : 0);
   let height = sh + (e.includes("s") ? dy : 0) - (e.includes("n") ? dy : 0);
-  width = clampNumber(width, POPOVER_MIN_WIDTH, maxWidth);
+  width = clampNumber(width, effectiveMinWidth, maxWidth);
   height = clampNumber(height, POPOVER_MIN_HEIGHT, maxHeight);
 
   let x = e.includes("w") ? right - width : sx;
@@ -362,6 +377,8 @@ function createPopover() {
 
   popover.on("closed", () => {
     clearTimeout(popoverSizeSaveTimer);
+    htmlPanelOpen = false;
+    htmlPanelWidth = 0;
     popover = null;
   });
 }
@@ -621,6 +638,37 @@ function collapsePopoverToDesktopPet() {
     popover.setOpacity(1);
     pet.showInactive();
   });
+}
+
+// ============================================================
+//  HTML Preview side panel — expand / shrink the popover width.
+// ============================================================
+function openHtmlPanel(width) {
+  if (htmlPanelOpen || !popover || popover.isDestroyed()) return;
+  const panelWidth = Math.max(HTML_PANEL_MIN_WIDTH, Number.isFinite(width) ? width : HTML_PANEL_MIN_WIDTH);
+  const bounds = popover.getBounds();
+  const display = screen.getDisplayMatching(bounds);
+  const work = display.workArea;
+  const newWidth = Math.min(bounds.width + panelWidth, work.width - POPOVER_EDGE_MARGIN);
+  if (newWidth <= bounds.width) return;
+  let newX = bounds.x;
+  if (bounds.x + newWidth > work.x + work.width - POPOVER_EDGE_MARGIN) {
+    newX = Math.max(work.x + 4, work.x + work.width - newWidth - POPOVER_EDGE_MARGIN);
+  }
+  htmlPanelOpen = true;
+  htmlPanelWidth = panelWidth;
+  popover.setBounds({ x: newX, y: bounds.y, width: newWidth, height: bounds.height }, true);
+  scheduleSavePopoverSize();
+}
+
+function closeHtmlPanel() {
+  if (!htmlPanelOpen || !popover || popover.isDestroyed()) return;
+  htmlPanelOpen = false;
+  const bounds = popover.getBounds();
+  const newWidth = Math.max(POPOVER_MIN_WIDTH, bounds.width - htmlPanelWidth);
+  popover.setBounds({ x: bounds.x, y: bounds.y, width: newWidth, height: bounds.height }, true);
+  htmlPanelWidth = 0;
+  scheduleSavePopoverSize();
 }
 
 // ============================================================
@@ -1478,4 +1526,30 @@ ipcMain.handle("settings:pick-cwd", async () => {
     settings.set({ chatCwd: result.filePaths[0] });
   }
   return buildSettingsState();
+});
+
+ipcMain.handle("popover:preview-open", (_, payload) => {
+  openHtmlPanel(payload?.width);
+});
+
+ipcMain.handle("popover:preview-close", () => {
+  closeHtmlPanel();
+});
+
+ipcMain.handle("html:open-in-browser", async (_, payload) => {
+  const html = String(payload?.html || "");
+  if (!html.trim()) return { ok: false, reason: "empty content" };
+  const tempFile = path.join(os.tmpdir(), `prts-preview-${Date.now()}.html`);
+  try {
+    fs.writeFileSync(tempFile, html, "utf8");
+    const error = await shell.openPath(tempFile);
+    if (error) {
+      console.warn("main: shell.openPath failed:", error);
+      return { ok: false, reason: error };
+    }
+    return { ok: true, path: tempFile };
+  } catch (err) {
+    console.warn("main: failed to write temp HTML:", err);
+    return { ok: false, reason: err.message };
+  }
 });

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -24,6 +24,12 @@ contextBridge.exposeInMainWorld("petApi", {
   onSettings: onChannel("settings:state")
 });
 
+contextBridge.exposeInMainWorld("previewApi", {
+  open: (payload) => ipcRenderer.invoke("popover:preview-open", payload),
+  close: () => ipcRenderer.invoke("popover:preview-close"),
+  openInBrowser: (payload) => ipcRenderer.invoke("html:open-in-browser", payload)
+});
+
 contextBridge.exposeInMainWorld("chatApi", {
   send: (text) => ipcRenderer.invoke("chat:send", text),
   cancel: () => ipcRenderer.invoke("chat:cancel"),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -25,7 +25,24 @@
       <div class="bubble" id="petBubble" aria-live="polite"></div>
     </section>
 
-    <main class="chat-stream" id="chatStream" aria-live="polite"></main>
+    <div class="main-area" id="mainArea">
+      <main class="chat-stream" id="chatStream" aria-live="polite"></main>
+      <div class="preview-divider" id="previewDivider" hidden aria-hidden="true"></div>
+      <aside class="html-preview" id="htmlPreview" hidden>
+        <header class="preview-header">
+          <span class="preview-title" id="previewTitle">HTML Preview</span>
+          <div class="preview-actions">
+            <button type="button" id="openInBrowserBtn" class="ghost preview-btn" title="Open in default browser">Open in Browser</button>
+            <button type="button" id="closePreviewBtn" class="ghost preview-btn preview-close" title="Close preview">&times;</button>
+          </div>
+        </header>
+        <iframe id="previewFrame"
+                sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
+                srcdoc=""
+                title="HTML Preview"
+                allow="clipboard-write"></iframe>
+      </aside>
+    </div>
 
     <footer class="composer">
       <form id="composer" autocomplete="off">

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -15,6 +15,32 @@ const cancelBtn = document.getElementById("cancelBtn");
 const clearBtn = document.getElementById("clearBtn");
 const cwdLine = document.getElementById("cwdLine");
 
+// HTML Preview Panel
+const mainArea = document.getElementById("mainArea");
+const htmlPreview = document.getElementById("htmlPreview");
+const previewFrame = document.getElementById("previewFrame");
+const previewDivider = document.getElementById("previewDivider");
+const previewTitle = document.getElementById("previewTitle");
+const openInBrowserBtn = document.getElementById("openInBrowserBtn");
+const closePreviewBtn = document.getElementById("closePreviewBtn");
+
+const PREVIEW_SPLIT_MIN = 0.28;
+const PREVIEW_SPLIT_MAX = 0.68;
+const htmlStore = new Map(); // messageId → htmlContent
+const dismissedPreviewIds = new Set(); // messageIds the user manually closed
+let activePreviewId = null;
+let htmlPanelOpen = false;
+let splitRatio = 0.5;
+try {
+  const saved = localStorage.getItem("htmlPanelSplitRatio");
+  if (saved != null) {
+    const n = parseFloat(saved);
+    if (Number.isFinite(n) && n >= PREVIEW_SPLIT_MIN && n <= PREVIEW_SPLIT_MAX) {
+      splitRatio = n;
+    }
+  }
+} catch { /* localStorage blocked */ }
+
 // ============================================================
 //  Frame loading — same edge-flood-fill technique as before.
 // ============================================================
@@ -1109,6 +1135,144 @@ function buildMsgEl(msg) {
   return el;
 }
 
+// ============================================================
+//  HTML Preview Panel — logic.
+// ============================================================
+function updateLayoutSplit() {
+  if (!htmlPanelOpen) {
+    chatStream.style.flexGrow = "1";
+    if (htmlPreview) htmlPreview.style.flexGrow = "0";
+    return;
+  }
+  const ratio = Math.min(PREVIEW_SPLIT_MAX, Math.max(PREVIEW_SPLIT_MIN, splitRatio));
+  chatStream.style.flexGrow = String(1 - ratio);
+  if (htmlPreview) {
+    htmlPreview.style.flexGrow = String(ratio);
+    htmlPreview.classList.add("open");
+  }
+}
+
+function syncPreviewButtons() {
+  const buttons = chatStream.querySelectorAll(".msg-preview-btn");
+  for (const btn of buttons) {
+    const mid = btn.dataset.previewId;
+    btn.classList.toggle("active", mid === activePreviewId);
+    btn.textContent = mid === activePreviewId ? "▼ Preview" : "▸ Preview";
+  }
+  if (htmlPanelOpen && activePreviewId) {
+    const msg = lastHistory.find((m) => m.id === activePreviewId);
+    const label = msg ? (msg.id || "").slice(-8) : activePreviewId.slice(-8);
+    previewTitle.textContent = `HTML Preview · ${label}`;
+  } else {
+    previewTitle.textContent = "HTML Preview";
+  }
+}
+
+function updatePreviewFrame(html) {
+  if (previewFrame && previewFrame.srcdoc !== html) {
+    previewFrame.srcdoc = html;
+  }
+}
+
+function switchToMessage(messageId) {
+  const html = htmlStore.get(messageId);
+  if (!html) return;
+  activePreviewId = messageId;
+  updatePreviewFrame(html);
+  syncPreviewButtons();
+}
+
+async function openHtmlPanelFor(messageId) {
+  const html = htmlStore.get(messageId);
+  if (!html) return;
+  dismissedPreviewIds.delete(messageId);
+  activePreviewId = messageId;
+  htmlPanelOpen = true;
+  htmlPreview.hidden = false;
+  previewDivider.hidden = false;
+  updatePreviewFrame(html);
+  updateLayoutSplit();
+  syncPreviewButtons();
+  try {
+    await window.previewApi?.open?.({ width: 200 });
+  } catch { /* no-op if IPC missing */ }
+}
+
+async function closeHtmlPanel() {
+  if (!htmlPanelOpen) return;
+  if (activePreviewId) dismissedPreviewIds.add(activePreviewId);
+  htmlPanelOpen = false;
+  activePreviewId = null;
+  htmlPreview.hidden = true;
+  previewDivider.hidden = true;
+  updateLayoutSplit();
+  syncPreviewButtons();
+  try {
+    await window.previewApi?.close?.();
+  } catch { /* no-op */ }
+}
+
+function detectHtmlBlocks() {
+  htmlStore.clear();
+  const codeBlocks = chatStream.querySelectorAll("pre code[class*='lang-html']");
+  let latestId = null;
+  for (const block of codeBlocks) {
+    const msgEl = block.closest(".msg.assistant");
+    if (!msgEl) continue;
+    const messageId = msgEl.dataset.id;
+    if (!messageId) continue;
+    const text = (block.textContent || "").trim();
+    if (!text) continue;
+    htmlStore.set(messageId, text);
+    latestId = messageId;
+  }
+  return latestId;
+}
+
+function addPreviewButtons() {
+  for (const [messageId] of htmlStore) {
+    const msgEl = chatStream.querySelector(`.msg.assistant[data-id="${messageId}"]`);
+    if (!msgEl || msgEl.querySelector(".msg-preview-btn")) continue;
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "msg-preview-btn";
+    btn.dataset.previewId = messageId;
+    btn.textContent = messageId === activePreviewId ? "▼ Preview" : "▸ Preview";
+    btn.addEventListener("click", () => {
+      if (htmlPanelOpen && activePreviewId === messageId) return;
+      if (htmlPanelOpen) {
+        switchToMessage(messageId);
+      } else {
+        openHtmlPanelFor(messageId);
+      }
+    });
+    msgEl.append(btn);
+  }
+  syncPreviewButtons();
+}
+
+function checkAndUpdateHtmlPreview() {
+  if (chatRunning) return;
+  // Remember which message IDs were already in the store so we can tell
+  // whether a genuinely new HTML reply arrived (should auto-open) vs an
+  // old one the user dismissed (should stay closed).
+  const oldIds = new Set(htmlStore.keys());
+  const latestId = detectHtmlBlocks();
+  // Newly appeared HTML blocks (from a fresh reply) clear their dismissed
+  // flag so they auto-open even if a previous block was manually closed.
+  for (const id of htmlStore.keys()) {
+    if (!oldIds.has(id)) dismissedPreviewIds.delete(id);
+  }
+  addPreviewButtons();
+  if (latestId) {
+    if (htmlPanelOpen) {
+      switchToMessage(latestId);
+    } else if (!dismissedPreviewIds.has(latestId)) {
+      openHtmlPanelFor(latestId);
+    }
+  }
+}
+
 function renderHistory(history) {
   // Preserve the reading position: every tool pill / output update re-renders
   // the whole stream, and unconditionally jumping to the bottom yanked the
@@ -1127,6 +1291,7 @@ function renderHistory(history) {
     empty.textContent = "Say something to start.";
     chatStream.append(empty);
     currentAssistantId = null;
+    checkAndUpdateHtmlPreview();
     return;
   }
   const assistants = lastHistory.filter((m) => m.role === "assistant");
@@ -1141,6 +1306,7 @@ function renderHistory(history) {
   } else {
     chatStream.scrollTop = prevScrollTop;
   }
+  checkAndUpdateHtmlPreview();
 }
 
 // Typewriter — backends often emit chunks in bursts, which makes the response
@@ -1351,6 +1517,9 @@ clearBtn.addEventListener("click", () => {
   if (!confirm("Clear current session? Long-term memory will be kept.")) return;
   window.chatApi.clear();
   showBubble("Conversation cleared.", 1800);
+  htmlStore.clear();
+  dismissedPreviewIds.clear();
+  if (htmlPanelOpen) closeHtmlPanel();
 });
 
 window.chatApi.onHistory((history) => renderHistory(history));
@@ -1492,6 +1661,65 @@ window.addEventListener("keydown", notePopoverActivity, { passive: true });
 //  Click on the character — angry / threat / wake-up reactions.
 // ============================================================
 stage.addEventListener("click", handleStageClick);
+
+// ============================================================
+//  HTML Preview Panel — divider drag + button handlers.
+// ============================================================
+let splitterDragging = false;
+
+previewDivider.addEventListener("pointerdown", (event) => {
+  if (event.button !== 0) return;
+  event.preventDefault();
+  splitterDragging = true;
+  previewDivider.classList.add("dragging");
+  document.body.style.userSelect = "none";
+  document.body.style.cursor = "col-resize";
+  try { previewDivider.setPointerCapture(event.pointerId); } catch { /* continue */ }
+});
+
+document.addEventListener("pointermove", (event) => {
+  if (!splitterDragging || !mainArea) return;
+  const rect = mainArea.getBoundingClientRect();
+  if (rect.width <= 0) return;
+  const mouseX = event.clientX - rect.left;
+  const rightRatio = 1 - Math.min(1, Math.max(0, mouseX / rect.width));
+  splitRatio = Math.min(PREVIEW_SPLIT_MAX, Math.max(PREVIEW_SPLIT_MIN, rightRatio));
+  updateLayoutSplit();
+});
+
+document.addEventListener("pointerup", (event) => {
+  if (!splitterDragging) return;
+  splitterDragging = false;
+  previewDivider.classList.remove("dragging");
+  document.body.style.userSelect = "";
+  document.body.style.cursor = "";
+  try { previewDivider.releasePointerCapture(event.pointerId); } catch { /* continue */ }
+  try { localStorage.setItem("htmlPanelSplitRatio", String(splitRatio)); } catch { /* blocked */ }
+});
+
+document.addEventListener("pointercancel", (event) => {
+  if (!splitterDragging) return;
+  splitterDragging = false;
+  previewDivider.classList.remove("dragging");
+  document.body.style.userSelect = "";
+  document.body.style.cursor = "";
+  try { previewDivider.releasePointerCapture(event.pointerId); } catch { /* continue */ }
+});
+
+closePreviewBtn.addEventListener("click", () => closeHtmlPanel());
+
+openInBrowserBtn.addEventListener("click", async () => {
+  const html = activePreviewId ? htmlStore.get(activePreviewId) : null;
+  if (!html) return;
+  try {
+    const result = await window.previewApi?.openInBrowser?.({ html });
+    if (result?.ok) {
+      showBubble("Opened in browser.", 1800);
+    }
+  } catch {
+    showBubble("Failed to open browser.", 3000);
+  }
+});
 
 // ============================================================
 //  Boot

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -289,10 +289,22 @@ button.ghost:disabled {
 }
 
 /* ============================================================
+   Main area — wraps chat-stream + optional HTML preview panel.
+   ============================================================ */
+.main-area {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: row;
+  overflow: hidden;
+}
+
+/* ============================================================
    Chat stream — pro-terminal feel.
    ============================================================ */
 .chat-stream {
   flex: 1;
+  min-width: 120px;
   min-height: 112px;
   overflow-y: auto;
   padding: 12px 14px 8px;
@@ -736,4 +748,112 @@ button.primary:disabled {
   background:
     linear-gradient(135deg, transparent 58%, var(--border-strong) 58%, var(--border-strong) 64%, transparent 64%),
     linear-gradient(135deg, transparent 72%, var(--border-strong) 72%, var(--border-strong) 78%, transparent 78%);
+}
+
+/* ============================================================
+   HTML Preview side panel — slides open on the right.
+   ============================================================ */
+.preview-divider {
+  flex: 0 0 6px;
+  cursor: col-resize;
+  background: var(--border);
+  z-index: 2;
+  transition: background 120ms ease;
+}
+
+.preview-divider:hover,
+.preview-divider.dragging {
+  background: var(--border-strong);
+}
+
+.preview-divider[hidden] {
+  display: none;
+}
+
+.html-preview {
+  flex: 0;
+  min-width: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--border);
+  background: var(--chat-bg);
+}
+
+.html-preview.open {
+  min-width: 200px;
+}
+
+.html-preview[hidden] {
+  display: none;
+}
+
+.preview-header {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bar-bg);
+  gap: 8px;
+}
+
+.preview-title {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.preview-actions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.preview-btn {
+  font-size: 10px;
+  padding: 2px 7px;
+  white-space: nowrap;
+}
+
+.preview-close {
+  font-size: 13px;
+  padding: 2px 5px;
+  line-height: 1;
+}
+
+#previewFrame {
+  flex: 1;
+  width: 100%;
+  border: none;
+  background: #fff;
+}
+
+/* ---- preview button inside assistant message bubbles ---- */
+.msg-preview-btn {
+  display: inline-block;
+  margin-top: 4px;
+  font-size: 10.5px;
+  padding: 2px 8px;
+  border-radius: 5px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--her);
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.msg-preview-btn:hover {
+  background: var(--her-soft);
+}
+
+.msg-preview-btn.active {
+  background: var(--her-soft);
+  border-color: var(--her-edge);
 }


### PR DESCRIPTION
当 AI 回复中包含 \``html` 代码块时，自动在对话框右侧展开一个可调节宽度的侧边面板，在沙盒 iframe 中实时渲染该 HTML 页面。每条消息的 HTML 独立保存，可通过消息气泡上的按钮自由切换查看。

 Feature
  - 自动检测与渲染: 当 AI 回复中包含 \``html` 代码块时，流式输出结束后自动在右侧面板打开最新页面的沙盒 iframe 预览
  - 独立保存与切换: 每条包含 HTML 的 assistant 消息独立存储，气泡底部出现 ▸ Preview / ▼ Preview 按钮，可切换查看历史  HTML
  - 关闭记忆: 用户手动关闭面板后，同一条 HTML 不会再次自动弹出。只有当新回复包含 HTML 时才会重新自动打开
  - 拖拽调节宽度: 面板与聊天区之间有一根 6px 的分隔条，Pointer Events 拖拽调节比例（28%~68%），比例持久化到 localStorage
  - 在浏览器中打开: 面板顶栏的 "Open in Browser" 按钮将当前 HTML 写入临时文件（%TEMP%/prts-preview-*.html），通过  shell.openPath() 在默认浏览器打开

  新增ui元素：
当回复中包含html代码块时，对话框下会自动出现一个preview按钮，用户可以通过此按钮在对话中看到html网页的渲染。
<img width="550" height="623" alt="屏幕截图 2026-06-10 124526" src="https://github.com/user-attachments/assets/5231a4e8-884d-4128-b742-e190d61335cd" />


  Compatibility
  - macOS + Windows 双平台兼容
  - 向下兼容: 无 HTML 代码块的聊天行为完全不变。#chatStream id 保持不变，无需修改现有引用
  - Stage 不折叠: 与桌面宠物、角色动画系统无冲突
  - contextIsolation + sandbox: iframe 使用 sandbox="allow-scripts allow-same-origin allow-forms allow-modals"，排除
  allow-top-navigation、allow-popups，通过 srcdoc 加载防止导航到外部 URL
  - Resize 约束: 面板打开时窗口最小宽度自动提升至 520px（320 + 200），关闭后恢复 320px

sry我手痒了（
顺带一提，牢普好看