### PR TITLE
fix: preserve attachments on retry

### DIFF
--- a/scripts/check-assets.js
+++ b/scripts/check-assets.js
@@ -34,6 +34,9 @@ const required = [
   path.join("assets", "character", "casual", "威胁.png"),
   path.join("assets", "character", "casual", "哭唧唧.png"),
   path.join("assets", "character", "casual", "睡觉.png"),
+  // 普猫猫彩蛋资源会在主界面和桌宠启动时预加载。
+  path.join("assets", "character", "普猫猫", "普猫猫.png"),
+  path.join("assets", "character", "普猫猫", "普猫猫哭.png"),
   path.join("assets", "character", "icon.png")
 ];
 

--- a/src/main/chat.js
+++ b/src/main/chat.js
@@ -164,7 +164,7 @@ function resolveAttachmentsForBackend(paths) {
   if (!paths.some(isImagePath)) return paths;
   let dir = null;
   let img = null;
-  return paths.map((p) => {
+  return paths.map((p, index) => {
     if (!isImagePath(p)) return p;
     try {
       const { nativeImage } = require("electron");
@@ -181,7 +181,8 @@ function resolveAttachmentsForBackend(paths) {
         fs.rmSync(dir, { recursive: true, force: true });
         fs.mkdirSync(dir, { recursive: true });
       }
-      const out = path.join(dir, path.basename(p).replace(/\.[^.]+$/, "") + ".png");
+      const base = path.basename(p).replace(/\.[^.]+$/, "");
+      const out = path.join(dir, `${String(index).padStart(2, "0")}-${base}.png`);
       fs.writeFileSync(out, resized.toPNG());
       return out;
     } catch {
@@ -2487,7 +2488,8 @@ async function launchProviderTurn({
       setImmediate(() => dispatchSend(trimmed, {
         userAlreadyShown: true,
         chained: true,
-        silentUser: Boolean(retrySilentKind)
+        silentUser: Boolean(retrySilentKind),
+        attachments: pendingAttachments
       }));
       return;
     }
@@ -2515,7 +2517,8 @@ async function launchProviderTurn({
       setImmediate(() => dispatchSend(trimmed, {
         userAlreadyShown: true,
         chained: true,
-        silentUser: Boolean(retrySilentKind)
+        silentUser: Boolean(retrySilentKind),
+        attachments: pendingAttachments
       }));
       return;
     }


### PR DESCRIPTION
## Summary
- Preserve this turn's backend attachment paths when retrying after Claude resume/model fallback failures.
- Avoid collisions when downscaled temp images share the same basename.
- Extend asset lint coverage to the preloaded 普猫猫 desktop pet resources.

## Verification
- npm run lint
- node --check src/main/chat.js
- node --check scripts/check-assets.js
- npm audit --omit=dev
- git diff --check

Note: I could not run a GUI smoke test in this local workspace because the Electron binary in node_modules is incomplete and download failed with `fetch failed`.