### PR TITLE
fix: stop reply button now terminates the running CLI turn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ CLAUDE.md
 
 # VS Code extension build output
 vscode-extension/out/
+vscode-extension/.vscode-test/
 *.vsix
 GPT-SoVITS-v2pro-20250604/

--- a/src/main/chat.js
+++ b/src/main/chat.js
@@ -2790,7 +2790,7 @@ async function launchProviderTurn({
   });
 
   proc.on("error", (error) => {
-    if (currentProcess !== proc) return;
+    if (currentProcess && currentProcess !== proc) return;
     cleanupInvocation(invocation);
     pushSystem(`\`${providerLabel(provider)}\` process error: ${error.message}`);
     finalizeAssistant("");
@@ -2812,7 +2812,7 @@ async function launchProviderTurn({
   });
 
   proc.on("close", (code) => {
-    if (currentProcess !== proc) return;
+    if (currentProcess && currentProcess !== proc) return;
     if (buffer.trim()) {
       try {
         handleProviderStreamEvent(provider, JSON.parse(buffer.trim()));


### PR DESCRIPTION
Bug：托盘主界面"停止回复"按钮无效
根因：cancel() 先置 currentProcess = null 再 kill，但 close/error handler 守卫 currentProcess !== proc 因此提前 return，跳过 finishTurn()（发 idle 状态）→ UI 卡在 running
修复：守卫改为 currentProcess && currentProcess !== proc（chat.js 2824/2846 行）
