### PR TITLE
fix: upgrade js-yaml to 4.3.1, 3.15.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2320,9 +2320,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code-but-priestess",
   "version": "0.7.6",
-  "description": "A cross-platform tray companion that lets you chat with 普瑞赛斯, backed by local Claude Code or Codex CLI usage.",
+  "description": "A cross-platform tray companion that lets you chat with \u666e\u745e\u8d5b\u65af, backed by local Claude Code or Codex CLI usage.",
   "main": "src/main/main.js",
   "private": true,
   "scripts": {
@@ -81,5 +81,8 @@
   "dependencies": {
     "electron-updater": "^6.8.9",
     "ws": "^8.18.0"
+  },
+  "overrides": {
+    "js-yaml": "4.3.1"
   }
 }


### PR DESCRIPTION
Closed by the maintainer.

Original body redacted: unsolicited automated pull request containing promotional content.

The underlying dependency bump (js-yaml 4.3.0 → 4.3.1, GHSA-5p4m-2wfm-xmqj) was valid and has been applied directly via `npm update js-yaml`.
